### PR TITLE
Fix: 컬러값 수정 및 태그 레이아웃 깨짐 수정

### DIFF
--- a/src/components/searchfilter/FilterTag.vue
+++ b/src/components/searchfilter/FilterTag.vue
@@ -13,11 +13,11 @@ const toggle = () => {
 <template>
   <button
     @click="toggle"
-    class="h-[30px] text-[12px] text-center rounded-[5px] px-[10px] border"
+    class="h-[30px] text-[12px] text-center rounded-[5px] px-[8px] border"
     :class="
       modelValue
-        ? 'bg-[#4B3C2F] text-[#FFFFFF] border-[#4B3C2F]'
-        : 'bg-[#FFFFFF] text-[#222222] border-[#E0E0E0]'
+        ? 'bg-[--primary] text-[--white] border-[--primary]'
+        : 'bg-[--white] text-[--black] border-[#E0E0E0]'
     "
   >
     {{ label }}


### PR DESCRIPTION
## 📝작업 내용

> 태그 4글자 이상 시 박스 바깥으로 벗어나던 거 수정, 컬러값 수정
![image](https://github.com/user-attachments/assets/89629ff3-37fc-4636-b326-7c8e8223823b)
